### PR TITLE
chore: update ftp-srv to 4.3.4

### DIFF
--- a/ftp/package.json
+++ b/ftp/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "bcrypt": "^4.0.0",
-    "ftp-srv": "^4.3.1",
+    "ftp-srv": "^4.3.4",
     "meteor-node-stubs": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We've just fixed a critical security vulnerability in `ftp-srv`, and though your dependencies are not pinned, I thought I would bring this into your view directly.

https://github.com/autovance/ftp-srv/security/advisories/GHSA-jw37-5gqr-cf9j